### PR TITLE
Use isort to fix module order in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,6 @@ __version__ = "0.2.0"
 
 
 # imports
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 setup(name="SeqEN2", version=__version__, packages=find_packages())


### PR DESCRIPTION
PEP-8 is the style guide folks use for Python.
Black handles many of these, but leaves some for more specialized tools.
One is ordering of imports.

PEP-8 says imports should be in three groups, separated by blank lines:
	standard modules
	third-party modules
	local modules
and these groups should be separated by blank lines.

Within groups, the module order should be alphabetical.

isort handles this. It has a lot of options (???),
but to work well with black, just use "--profile black"

You can fix a whole directory tree like this:

    isort --profile black .  # note the "." at the end

This commit only uses it to fix setup.py.