### PR TITLE
Utility to run isort and black in pre-commit hook.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,20 @@
+repos:
+  - repo: local
+    hooks:
+      - id: isort
+        name: Sorting import statements
+        entry: bash -c 'isort "$@"; git add -u' --
+        language: python
+        args: ["--profile", "black", "--filter-files"]
+        files: \.py$
+      - id: black
+        name: Black Python code formatting
+        entry: bash -c 'black "$@"; git add -u' --
+        language: python
+        types: [python]
+        args: ["--line-length=120"]
+      - id: mypy
+        name: Optional static type checker
+        entry: bash -c 'mypy "$@"; git add -u' --
+        language: python
+        files: \.py$

--- a/bin/pre-commit-setup.sh
+++ b/bin/pre-commit-setup.sh
@@ -1,0 +1,28 @@
+#!/bin/bash -eu
+# Get Git to run isort and black on each Python file commit
+
+pip install pre-commit                      # install Python's Git pre-commit utility
+cat > .pre-commit-config.yaml <<'__EOF__'   # configure to run isort and black
+repos:
+  - repo: local
+    hooks:
+      - id: isort
+        name: Sorting import statements
+        entry: bash -c 'isort "$@"; git add -u' --
+        language: python
+        args: ["--profile", "black", "--filter-files"]
+        files: \.py$
+      - id: black
+        name: Black Python code formatting
+        entry: bash -c 'black "$@"; git add -u' --
+        language: python
+        types: [python]
+        args: ["--line-length=120"]
+      - id: mypy
+        name: Optional static type checker
+        entry: bash -c 'mypy "$@"; git add -u' --
+        language: python
+        files: \.py$
+__EOF__
+
+pre-commit install                     # tell pre-commit to create a .git/hooks/pre-commit from the YAML


### PR DESCRIPTION
A simple shell script to

	1) Install pre-commit utility.
	2) Create the yaml to configure the hook.
	3) Run the utility to create the hook itself.

Running the script once to save
both the work of running isort and black, by hand, before every commit,
and the work of remembering to do so.

The configuration (step 2) may expand later, but this is a useful start.